### PR TITLE
Fixes issue on lockout observation window detection 

### DIFF
--- a/DomainPasswordSpray.ps1
+++ b/DomainPasswordSpray.ps1
@@ -535,7 +535,11 @@ function Get-ObservationWindow($DomainEntry)
 {
     # Get account lockout observation window to avoid running more than 1
     # password spray per observation window.
-    $lockObservationWindow_attr = $DomainEntry.Properties['lockoutObservationWindow']
-    $observation_window = $DomainEntry.ConvertLargeIntegerToInt64($lockObservationWindow_attr.Value) / -600000000
-    return $observation_window
+	$RootDSE = Get-ADRootDSE -Server $env:USERDNSDOMAIN
+    $lockObservationWindow_attr = Get-ADObject $RootDSE.defaultNamingContext -Property lockoutObservationWindow | select-object -expand lockoutObservationwindow
+	$lockObservationWindow_attr = -$lockObservationWindow_attr
+	$lockObservationWindow_attr = $lockObservationWindow_attr / 60 / 10000000
+
+	$observation_window = $lockObservationWindow_attr
+	return $observation_window
 }

--- a/DomainPasswordSpray.ps1
+++ b/DomainPasswordSpray.ps1
@@ -536,10 +536,8 @@ function Get-ObservationWindow($DomainEntry)
     # Get account lockout observation window to avoid running more than 1
     # password spray per observation window.
 	$RootDSE = Get-ADRootDSE -Server $env:USERDNSDOMAIN
-    $lockObservationWindow_attr = Get-ADObject $RootDSE.defaultNamingContext -Property lockoutObservationWindow | select-object -expand lockoutObservationwindow
-	$lockObservationWindow_attr = -$lockObservationWindow_attr
-	$lockObservationWindow_attr = $lockObservationWindow_attr / 60 / 10000000
-
+   	$lockObservationWindow_attr = Get-ADObject $RootDSE.defaultNamingContext -Property lockoutObservationWindow | select-object -expand lockoutObservationwindow
+    	$lockObservationWindow_attr = -$lockObservationWindow_attr / 600000000
 	$observation_window = $lockObservationWindow_attr
 	return $observation_window
 }


### PR DESCRIPTION
For an unknown reason, on Windows 10 Version 10.0.18363 with PowerShell 5.1, the current code fails to properly detect lockout Windows and reports errors about NullArray and ConvertLargeIntegerToInt64

This rewrites the Get-ObservationWindow function to work with above Window 10 / PowerShell version. 