### PR TITLE
Update DomainPasswordSpray.ps1

### DIFF
--- a/DomainPasswordSpray.ps1
+++ b/DomainPasswordSpray.ps1
@@ -535,6 +535,7 @@ function Get-ObservationWindow($DomainEntry)
 {
     # Get account lockout observation window to avoid running more than 1
     # password spray per observation window.
+    $DomainEntry = [ADSI]$DomainEntry
     $lockObservationWindow_attr = $DomainEntry.Properties['lockoutObservationWindow']
     $observation_window = $DomainEntry.ConvertLargeIntegerToInt64($lockObservationWindow_attr.Value) / -600000000
     return $observation_window


### PR DESCRIPTION
Eliminates the following error:
Cannot index into a null array.
At line:538 char:5
+     $lockObservationWindow_attr = $DomainEntry.Properties['lockoutObs ...
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : NullArray
