### PR TITLE
Fix for calls to Get-ObservationWindow

### DIFF
--- a/DomainPasswordSpray.ps1
+++ b/DomainPasswordSpray.ps1
@@ -181,7 +181,8 @@ function Invoke-DomainPasswordSpray{
         Write-Host -ForegroundColor Yellow "[*] WARNING - Be very careful not to lock out accounts with the password list option!"
     }
 
-    $observation_window = Get-ObservationWindow $CurrentDomain
+    $objDeDomain = [ADSI] "LDAP://$($DomainObject.PDCRoleOwner)"
+    $observation_window = Get-ObservationWindow $objDeDomain
 
     Write-Host -ForegroundColor Yellow "[*] The domain password policy observation window is set to $observation_window minutes."
     Write-Host "[*] Setting a $observation_window minute wait in between sprays."
@@ -374,7 +375,7 @@ function Get-DomainUserList
         }
     }
 
-    $observation_window = Get-ObservationWindow $CurrentDomain
+    $observation_window = Get-ObservationWindow $objDeDomain
 
     # Generate a userlist from the domain
     # Selecting the lowest account lockout threshold in the domain to avoid


### PR DESCRIPTION
 Apparently some Properties are not available when the current domain controller is not the PDC.