### PR TITLE
Update DomainPasswordSpray.ps1

### DIFF
--- a/DomainPasswordSpray.ps1
+++ b/DomainPasswordSpray.ps1
@@ -258,7 +258,7 @@ function Countdown-Timer
     )
     if ($quiet)
     {
-        Write-Host "$Message: Waiting for $($Seconds/60) minutes. $($Seconds - $Count)"
+        Write-Host "${Message}: Waiting for $($Seconds/60) minutes. $($Seconds - $Count)"
         Start-Sleep -Seconds $Seconds
     } else {
         foreach ($Count in (1..$Seconds))


### PR DESCRIPTION
fixing line 261 with tested bug fix code from currently open issue #38 to resolve "variable reference is not valid" error